### PR TITLE
return empty bytes after signal is set

### DIFF
--- a/Decoder.py
+++ b/Decoder.py
@@ -50,6 +50,8 @@ class QueueAdapter:
             except Exception as e:
                 logger.error(f"Unexpected excepton: {str(e)}")
 
+        return bytes()
+
 
 class NvDecoder:
     def __init__(self,


### PR DESCRIPTION
This MR fixes `QueueAdapter.read` method.
It now returns empty `bytes` after stop event is set.